### PR TITLE
Fixed broken link in the application deploy markdown

### DIFF
--- a/cloud-platform/app-deploy.md
+++ b/cloud-platform/app-deploy.md
@@ -23,7 +23,7 @@ This guide assumes the following:
 
 If you are not deploying your own application and would like to deploy the example application, clone the following repo:
 
-[https://github.com/ministryofjustice/cloud-platform-demo-app](https://github.com/ministryofjustice/cloud-platform-demo-app)
+[https://github.com/ministryofjustice/cloud-platform-reference-app](https://github.com/ministryofjustice/cloud-platform-reference-app)
 
 ## Pushing application to ECR
 


### PR DESCRIPTION
**WHAT**
A small change to the URL of the reference application repository in the application deploy document. 
**WHY**
Current link points to a blank repo. 