### PR TITLE
Env creation simplify

### DIFF
--- a/02-deploying-an-app/001-app-deploy-helm.md
+++ b/02-deploying-an-app/001-app-deploy-helm.md
@@ -2,7 +2,7 @@
 category: cloud-platform
 expires: 2018-01-31
 ---
-# Tutorial: Deploying an application to the Cloud Platform with Helm
+# Deploying an application to the Cloud Platform with Helm
 
 ## Introduction
 This document will act as a guide to your first application deployment into the Cloud Platform. If you have any issues completing the objective or have any suggestions please feel free to drop use a line in the #cloud-platform-users slack channel.


### PR DESCRIPTION
The environment creation page needed to be update to reflect the merging
of the previous two repos for creating environments into a single repo
(see ministryofjustice/cloud-platform#37).

So I've taken Alejandro's work to update the references to the previous
repos and additionally:

* removed any instructions on e.g. using git, doing PRs
* removed the photos of the repo from the page
* made the sections more simple
* moved around some of the content on namespaces, rolebindings etc
* simplified some of the language

The aim is to keep the main content but make it a little more like the [page that Jason
did](https://ministryofjustice.github.io/cloud-platform-user-docs/02-deploying-an-app/001-app-deploy-helm/#tutorial-deploying-an-application-to-the-cloud-platform-with-helm)
in structure.