### PR TITLE
'How do I access my logs?' Documentation

### DIFF
--- a/03-other-topics/004-kibana.md
+++ b/03-other-topics/004-kibana.md
@@ -1,6 +1,6 @@
 # How to accesss my log data
 ## Introduction
-This document is intended to assist engineers in accessing application and system logs stored in a centralised Elasticsearch cluster. Using a combination of Fluentd, AWS's Elasticsearch cluster and Kibana the Cloud Platform collects, indexes and presents your application and system log data. All that's required is that your application writes to stdout. 
+This document is intended to assist engineers in accessing application and system logs stored in a centralised Elasticsearch cluster. Using a combination of Fluentd, AWS's Elasticsearch cluster and Kibana the Cloud Platform collects, indexes and presents your application and system log data enabling you to query using Kibana’s standard query language (based on Lucene query syntax). All that's required is that your application writes to stdout. 
 
 Production and non-production data will be indexed in seperate clusters. 
 ## Quick start
@@ -8,6 +8,8 @@ Production and non-production data will be indexed in seperate clusters.
 ## How to get my data into Elasticsearch
 As long as your application is writing to stdout, it'll be collected by fluentd and passed to the Elasticsearch cluster. Use one of the links above and authenticate with your GitHub username and password. 
 ## How do I use Kibana?
+
 https://www.elastic.co/guide/en/kibana/6.3/search.html
+
 https://www.elastic.co/guide/en/beats/packetbeat/current/kibana-queries-filters.html
 

--- a/03-other-topics/004-kibana.md
+++ b/03-other-topics/004-kibana.md
@@ -4,8 +4,10 @@ This document is intended to assist engineers in accessing application and syste
 
 Production and non-production data will be indexed in seperate clusters. 
 ## Quick start
-<insert kibana link>
+-----kibana link------
 ## How to get my data into Elasticsearch
-As long as your application is writing to stdout, it'll be collected by fluentd and passed to the Elasticsearch cluster. 
+As long as your application is writing to stdout, it'll be collected by fluentd and passed to the Elasticsearch cluster. Use one of the links above and authenticate with your GitHub username and password. 
 ## How do I use Kibana?
-<insert elasticsearch links>
+https://www.elastic.co/guide/en/kibana/6.3/search.html
+https://www.elastic.co/guide/en/beats/packetbeat/current/kibana-queries-filters.html
+

--- a/03-other-topics/004-kibana.md
+++ b/03-other-topics/004-kibana.md
@@ -1,10 +1,14 @@
-# How to accesss my log data
+# How to access my log data using Kibana
 ## Introduction
 This document is intended to assist engineers in accessing application and system logs stored in a centralised Elasticsearch cluster. Using a combination of Fluentd, AWS's Elasticsearch cluster and Kibana the Cloud Platform collects, indexes and presents your application and system log data enabling you to query using Kibana’s standard query language (based on Lucene query syntax). All that's required is that your application writes to stdout. 
 
 Production and non-production data will be indexed in seperate clusters. 
 ## Quick start
------kibana link------
+Live
+https://kibana.apps.cloud-platform-live-0.k8s.integration.dsd.io/_plugin/kibana
+
+Test
+https://kibana.apps.cloud-platform-test-1.k8s.integration.dsd.io/_plugin/kibana
 ## How to get my data into Elasticsearch
 As long as your application is writing to stdout, it'll be collected by fluentd and passed to the Elasticsearch cluster. Use one of the links above and authenticate with your GitHub username and password. 
 ## How do I use Kibana?

--- a/03-other-topics/004-kibana.md
+++ b/03-other-topics/004-kibana.md
@@ -1,0 +1,11 @@
+# How to accesss my log data
+## Introduction
+This document is intended to assist engineers in accessing application and system logs stored in a centralised Elasticsearch cluster. Using a combination of Fluentd, AWS's Elasticsearch cluster and Kibana the Cloud Platform collects, indexes and presents your application and system log data. All that's required is that your application writes to stdout. 
+
+Production and non-production data will be indexed in seperate clusters. 
+## Quick start
+<insert kibana link>
+## How to get my data into Elasticsearch
+As long as your application is writing to stdout, it'll be collected by fluentd and passed to the Elasticsearch cluster. 
+## How do I use Kibana?
+<insert elasticsearch links>


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/cloud-platform/issues/288

**WHAT**
User documentation to show developers where they can access their log data.

**WHY** 
To ensure users can navigate to application log data.