### PR TITLE
Fix creating a file using cat command

### DIFF
--- a/01-getting-started/003-ecr-setup.md
+++ b/01-getting-started/003-ecr-setup.md
@@ -14,7 +14,7 @@ AWS resources are provisioned through the [cloud-platform-environments](https://
 In your local clone of the environments repository, `cd` to your environment's path and create a new directory called `resources`. Inside `resources`, create a new file called `ecr.tf`:
 
 ```
-$ cat ecr.tf
+$ cat > ecr.tf
 terraform {
   backend "s3" {}
 }
@@ -43,6 +43,7 @@ resource "kubernetes_secret" "ecr-repo" {
   }
 }
 ```
+Type [Ctrl-d] at the end to save the file.
 
 This will create an image repository at `<account_number>.dkr.ecr.eu-west-1.amazonaws.com/my-team-name/my-app-name` along with the credentials to push to it.
 


### PR DESCRIPTION
# What does this pull request do?

It updates the example `cat` command to create a file. 

## Why?
The example as it is doesn't create a file, so it might be a bit misleading to newcomers.
 