### PR TITLE
Fix broken helm init instructions

### DIFF
--- a/02-deploying-an-app/001-app-deploy-helm.md
+++ b/02-deploying-an-app/001-app-deploy-helm.md
@@ -58,7 +58,7 @@ Install the client via Homebrew or by other [means](https://docs.helm.sh/using_h
 
 Now configure the installation with Tiller:
 
-`$ helm init --tiller-namespace <env-name>`
+`$ helm init --tiller-namespace <env-name> --service-account tiller`
 
 When succesful, you'll be greeted with the message:
 


### PR DESCRIPTION
**WHAT**
Adding an additional switch onto the `helm init` instructions

**WHY**
A number of users are having problems and it's because this switch is missing. 