### PR TITLE
Remove all references to non-prod cluster in all documention 

### DIFF
--- a/01-getting-started/002-env-create.md
+++ b/01-getting-started/002-env-create.md
@@ -88,7 +88,7 @@ metadata:
   labels:
     name: myapp-dev # Also your $servicename-$env
 ```
-Example from the cloud-platform-reference-app [namespace file](https://github.com/ministryofjustice/cloud-platform-environments/blob/master/namespaces/non-production.k8s.integration.dsd.io/reference-app/namespace.yaml).
+Example from the cloud-platform-reference-app [namespace file](https://github.com/ministryofjustice/cloud-platform-environments/blob/master/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app/00-namespace.yaml).
 
 #### Rolebinding
 

--- a/02-deploying-an-app/001-app-deploy-helm.md
+++ b/02-deploying-an-app/001-app-deploy-helm.md
@@ -8,7 +8,7 @@ expires: 2018-01-31
 This document will act as a guide to your first application deployment into the Cloud Platform. If you have any issues completing the objective or have any suggestions please feel free to drop use a line in the #cloud-platform-users slack channel.
 
 ### Objective
-By the end of this guide you'll have deployed a reference [Django application](https://github.com/ministryofjustice/cloud-platform-reference-app) to a cluster for non-production appplications using the Kubernetes package manager [Helm](https://helm.sh/).
+By the end of this guide you'll have deployed a reference [Django application](https://github.com/ministryofjustice/cloud-platform-reference-app) to a cluster using the Kubernetes package manager [Helm](https://helm.sh/).
 
 *Disclaimer: You'll see fairly quickly that the application is not fit for production. A perfect example of this is the [plaintext secrets file](https://github.com/ministryofjustice/cloud-platform-reference-app/blob/master/helm_deploy/django-app/templates/secret.yaml). For the reference application we've left this file in plaintext but it **must** be encrypted when writing your own manifests for production/non-production work in the MoJ.*
 
@@ -18,7 +18,7 @@ It is assumed you have the following:
  - You have a basic understanding of what [Kubernetes](https://kubernetes.io/) is.
  - You have [created an environment for your application]({{ "/01-getting-started/002-env-create" | relative_url }})
  - You have installed [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) on your local machine.
- - You have [Authenticated]({{ "/01-getting-started/001-kubectl-config" | relative_url }}) to the cluster known as the 'non-production cluster'.
+ - You have [Authenticated]({{ "/01-getting-started/001-kubectl-config" | relative_url }}) to the cloud-platform-live-0 cluster.
 
 ## Deploy the app
 The reference application we're going to use is a very simple Django application with an on-cluster Postgresql database.

--- a/02-deploying-an-app/004-use-circleci-to-upgrade-app.md
+++ b/02-deploying-an-app/004-use-circleci-to-upgrade-app.md
@@ -21,8 +21,8 @@ By the end of the tutorial, you will have done the following:
 It is assumed you have the following:
 
  - You have [created an environment for your application](/01-getting-started/002-env-create)
- - You have [deployed an application](https://ministryofjustice.github.io/cloud-platform-user-docs/02-deploying-an-app/001-app-deploy-helm/#tutorial-deploying-an-application-to-the-cloud-platform-with-helm) to the 'non-production cluster' using Helm.
- - You have created an [ECR repository](TODO) (docs coming soon)
+ - You have [deployed an application](https://ministryofjustice.github.io/cloud-platform-user-docs/02-deploying-an-app/001-app-deploy-helm/#tutorial-deploying-an-application-to-the-cloud-platform-with-helm) to the 'cloud-platform-live-0' cluster using Helm.
+ - You have created an [ECR repository](/01-getting-started/003-ecr-setup/#creating-an-ecr-repository)
 
 ### Creating a Service Account for CircleCI
 As part of the CircleCI deployment pipeline, CircleCI will need to authenticate with the Kubernetes cluster. In order to do so, Kubernetes uses [Service Accounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/). Service Accounts provide an identity for processes that run in a cluster allowing the process to access the API server.


### PR DESCRIPTION
connects to https://github.com/ministryofjustice/cloud-platform/issues/327

**WHAT**
- Removes all references to the retiring 'non-production' cluster. I've either replaced or removed mention of the cluster. 
- Filled in a todo for ECR URL. 

**WHY**
- The non-production cluster will be retired shortly and all reference to it in the user documentation must be removed. 
- Noticed while removing non-production references there was an incomplete hyperlink. Added URL to the ECR repo creation. 