### PR TITLE
Convert live cluster login URL to link

### DIFF
--- a/01-getting-started/001-kubectl-config.md
+++ b/01-getting-started/001-kubectl-config.md
@@ -32,7 +32,7 @@ Live clusters are those available to users:
 
 | Cluster Name | Login page |
 | ------------ | ---------- |
-| `cloud-platform-live-0` | https://login.apps.cloud-platform-live-0.k8s.integration.dsd.io/ |
+| `cloud-platform-live-0` | [https://login.apps.cloud-platform-live-0.k8s.integration.dsd.io/](https://login.apps.cloud-platform-live-0.k8s.integration.dsd.io/) |
 
 ### How do I connect to a cluster?
 


### PR DESCRIPTION
On the [live page][live_page] the login URL is not a link. Presumably, it is due to some inconsistencies on how the page is rendered compared to how markdown is rendered.

This change adds the link explicitly.

**Before**
<img width="798" alt="screen shot 2018-09-06 at 10 23 00" src="https://user-images.githubusercontent.com/1526295/45148294-dded0200-b1be-11e8-911d-eb61f0af8026.png">

**After**
<img width="796" alt="screen shot 2018-09-06 at 10 34 07" src="https://user-images.githubusercontent.com/1526295/45148986-7b950100-b1c0-11e8-8f9f-948eb30b814b.png">


[live_page]: https://ministryofjustice.github.io/cloud-platform-user-docs/01-getting-started/001-kubectl-config/#live-clusters