### PR TITLE
Add troubleshooting related to unset current context

### DIFF
--- a/01-getting-started/001-kubectl-config.md
+++ b/01-getting-started/001-kubectl-config.md
@@ -45,6 +45,21 @@ To authenticate with a cluster, please follow the steps below;
  - Follow the instructions on the page presented, once finished you should have a [`kubeconfig`](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) file in `~/.kube/config`.
  - You should now be able to run `kubectl` commands; try running such `kubectl get namespaces`
 
+#### Troubleshooting: "current" context
+
+If you receive `The connection to the server localhost:8080 was refused` errors while executing `kubectl` commands,
+check that your "current" context is set.
+
+Run `kubectl config get-contexts`:
+```
+CURRENT   NAME                                           CLUSTER                                        AUTHINFO                 NAMESPACE
+          cloud-platform-live-0.k8s.integration.dsd.io   cloud-platform-live-0.k8s.integration.dsd.io   <your github e-mail>
+```
+
+Set the context you want to use as "current" with: `kubectl config use-context <NAME>`.
+
+E.g. `kubectl config use-context cloud-platform-live-0.k8s.integration.dsd.io`
+
 ### Multiple clusters
 To setup additional clusters, follow the process above and save the generated `kubeconfig` with a different filename (eg.: `~/.kube/config_live0`).
 


### PR DESCRIPTION
After following the steps outlined the "current" context in `kubectl` is still unset. This extension explains what steps need to be done.

This follows the Slack conversation that happened between @bleach and @nayoa in `#cloud-platform-users`:

> Graham Bleach [3:54 PM]
> Can't seem to get `kubectl` working. I've followed the steps in https://ministryofjustice.github.io/cloud-platform-user-docs/01-getting-started/001-kubectl-config/#authentication to authenticate via github, update my `.kube/config`
> The email address it chooses to use is a personal one.
> ```
> $ kubectl get namespaces
> The connection to the server localhost:8080 was refused - did you specify the right host or port?
> $ kubectl --cluster cloud-platform-live-0.k8s.integration.dsd.io get namespaces
> error: the server doesn't have a resource type "namespaces"
> $ kubectl --cluster cloud-platform-live-0.k8s.integration.dsd.io cluster-info dump
> error: You must be logged in to the server (Unauthorized)
> ```
> What am I missing?

> nayo [3:55 PM]
> Hey Graham Bleach - looks like you haven’t selected the context. Can you do a `kubectl config use-context cloud-platform-live-0.k8s.integration.dsd.io`
> `kubectl config get-contexts` to list them

> Graham Bleach [3:57 PM]
> Great, that fixes it
> Thanks