### PR TITLE
Update environment creation docs to use templates

### DIFF
--- a/01-getting-started/002-env-create.md
+++ b/01-getting-started/002-env-create.md
@@ -1,6 +1,6 @@
 ---
 category: cloud-platform
-expires: 2018-01-31
+expires: 2019-01-31
 ---
 # Creating a Cloud Platform Environment
 
@@ -10,7 +10,7 @@ This is a guide to creating a environment in one of our Kubernetes clusters.
 
 We define an environment as a Kubernetes [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) with some key resources deployed in it. Each Kubernetes namespace creates a logical separation within our cluster that provides isolation from any other namespace.
 
-Once you have created an environment you will be able to perform actions using the `kubectl` tool in the associated namespace.
+Once you have created an environment you will be able to perform actions using the `kubectl` tool in the namespace you have created.
 
 ## Objective
 
@@ -18,11 +18,11 @@ By the end of this guide you'll have created a Kubernetes namespace ready for yo
 
 ## Create an environment
 
-You create an environment by adding its definition in YAML to the following repository, hosted on GitHub:
+You create an environment by adding the definition of the environment in YAML to the following repository, hosted on GitHub:
 
 [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments)
 
-Adding your environment definition kicks off a pipeline which builds your namespace on the appropriate cluster and external AWS resources in the `mojds-platforms-integration` account `eu-west-1` region.
+Adding your environment definition kicks off a pipeline which builds your environment on the appropriate cluster.  
 
 ### Set up
 
@@ -31,28 +31,23 @@ First we need to clone the repository, change directory and create a new branch:
 ```
 $ git clone git@github.com:ministryofjustice/cloud-platform-environments.git
 $ cd cloud-platform-environments
-$ git checkout -b "yourBranch"
+$ git checkout -b <yourBranch>
 ```
 
 ### The directory structure
 
-We build new environments by creating a new directory and adding within YAML/HCL files that define it. To understand where to create the directory it is useful to glance at the repo structure:
+We build new environments by creating a new directory for our environment and putting the YAML files that define the environment into that directory. To understand where to create the directory it is useful to understand the overall structure of the repo:  
 
 ```
 cloud-platform-environments
+├── namespace-resources
 └── namespaces
-    └── cloud-platform-live-0.k8s.integration.dsd.io/
+    └── cloud-platform-live-0.k8s.integration.dsd.io
         ├── kube-system
+
         ...
-        ├── user-roles.yaml
-        ...
-        └── $servicename-$env/
-            ├── 00-namespace.yaml
-            ...
-            ├── 04-networkpolicy.yaml
-            ...
-            └── resources/
-                └── main.tf
+
+        └── user-roles.yaml
 ```
 
 **cloud-platform-environments**
@@ -61,21 +56,17 @@ This is the root of the repo, containing `namespaces` directory
 
 **/namespaces**
 
-The namespaces directory contains a directory for each of the clusters that you can build environments on. Create yours in the `cloud-platform-live-0.k8s.integration.dsd.io` directory.
+The namespaces directory contains a directory for each of the clusters that you can build environments on. Create your environment in the `cloud-platform-live-0.k8s.integration.dsd.io` directory.
 
 **/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/**
 
-Within the cluster directory you will create a directory for your namespace in the format `$servicename-$env`, for example `myapp-dev`.
+Within the cluster directory you will create a directory for your environment in the format `<servicename-env>`, for example `myapp-dev`.
 
-**/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/$servicename-$env**
+**/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/<servicename-env>**
 
-The `$servicename-$env` directory for your environment defines the specific resources we will create in your namespace. In this guide we create the base namespace definition and a rolebinding that sets who can perform actions on the namespace.
+The `<servicename-env>` directory for your environment defines the specific resources we will create in your namespace. In this guide we create the base namespace definition and a rolebinding that sets who can perform actions on the namespace.
 
-**/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/$servicename-$env/resources**
-
-The `resources` sub-directory must contain terraform files defining additional AWS resources based on available modules (currently [ECR / S3 / RDS / ElastiCache / DynamoDB](https://ministryofjustice.github.io/cloud-platform-user-docs/#deploying-an-app))
-
-### Defining your environment
+## Define your environment
 
 We create the environment by adding a directory in the `/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/` directory:
 
@@ -84,39 +75,59 @@ $ cd namespaces/cloud-platform-live-0.k8s.integration.dsd.io/
 $ mkdir myapp-dev
 ```
 
-Now we will need to create two files within our `$servicename-$env` directory,  `namespaces.yaml` and `$servicename-$env-admin-role.yaml`. The structures of both files are shown below.
+To set up an environment we need to create 5 files in our namespace:
 
-#### Namespace definition
+* [`00-namespace.yaml`](#00-namespaceyaml)
+* [`01-rbac.yaml`](#01-rbacyaml)
+* [`02-limitrange.yaml`](#02-limitrangeyaml)
+* [`03-resourcequota.yaml`](#03-resourcequotayaml)
+* [`04-networkpolicy.yaml`](#04-networkpolicyyaml)
 
-The `namespace.yaml` file defines the namespace so that the cluster Kubernetes knows to create a namespace and what to call it.
+These files define key elements of the namespace and restrictions we want to place on it so that we have security and resource allocation properties. We describe each of these files in more detail below.
+
+To get started copy the example versions of these files from the [`namespace-resources`](https://github.com/ministryofjustice/cloud-platform-environments/tree/master/namespace-resources) directory in the `cloud-platform-evironments` repo into your `<servicename-env>` directory.
+
+```Shell
+# From the root of the cloud-platform-environments directory
+$ cp namespace-resources/* namespaces/cloud-platform-live-0.k8s.integration.dsd.io/myapp-dev/
+```
+
+In each of these files you need to replace some example values with information about your namespace, team or app. We go through each of the changes below.
+
+After you have changed the files commit them and create a pull request against the [`cloud-platform-environments`](https://github.com/ministryofjustice/cloud-platform-environments) master repo.
+
+The cloud platform team will merge the pull request which will kick off the pipeline that builds the environment. You can check whether the build succeeded or failed in the [`#cp-build-notifications`](https://mojdt.slack.com/messages/CA5MDLM34/) slack channel.  
+
+### `00-namespace.yaml`
+
+The `00-namespace.yaml` file defines the namespace so that the cluster Kubernetes knows to create a namespace and what to call it.
 
 ```YAML
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: myapp-dev # This is where you will define your $servicename-$env
+  name: myapp-dev # This is where you will define your <servicename-env>
   labels:
-    name: myapp-dev # Also your $servicename-$env
+    name: myapp-dev # Also your <servicename-env>
 ```
-Example from the cloud-platform-reference-app [namespace file](https://github.com/ministryofjustice/cloud-platform-environments/blob/master/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app/00-namespace.yaml).
 
-#### Rolebinding
+### `01-rbac.yaml`
 
-We will also create a `RoleBinding` resource by adding a `$servicename-$env-admin-role.yaml` file. This will provide us with [access policies](https://kubernetes.io/docs/admin/authorization/rbac/) on the namespace we have created in the cluster.
+We will also create a `RoleBinding` resource by adding the `01-rbac.yaml` file. This will provide us with [access policies](https://kubernetes.io/docs/admin/authorization/rbac/) on the namespace we have created in the cluster.
 
 A role binding resource grants the permissions defined in a role to a user or set of users. A role can be another resource we can create but in this instance we will reference a Kubernetes default role `ClusterRole - admin`.
 
-This `RoleBinding` resource references the `ClusterRole - admin` to provide  admin permissions on the namespace to the set of users defined under `subjects`. In this case, the `$yourTeam` GitHub group will have admin access to any resources within the namespace `myapp-dev`.
+This `RoleBinding` resource references the `ClusterRole - admin` to provide  admin permissions on the namespace to the set of users defined under `subjects`. In this case, the `<yourTeam>` GitHub group will have admin access to any resources within the namespace `myapp-dev`.
 
 ```YAML
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: myapp-dev-admins  # Your namespace with `-admin` e.g. `$servicename-$env-admin`
-  namespace: myapp-dev # Your namespace `$servicename-$env`
+  name: myapp-dev-admins  # Your namespace with `-admin` e.g. `<servicename-env>-admin`
+  namespace: myapp-dev # Your namespace `<servicename-env>`
 subjects:
   - kind: Group
-    name: "github:$yourTeam" # Make this the name of the GitHub team you want to give access to
+    name: "github:<yourTeam>" # Make this the name of the GitHub team you want to give access to
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
@@ -124,22 +135,103 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-After both files are created commit them and create a pull request against the [`cloud-platform-environments`](https://github.com/ministryofjustice/cloud-platform-environments) master repo.
+### `02-limitrange.yaml`
 
-The cloud platform team will merge the pull request which will kick off a Concourse pipeline to build the environment. Once deployed all the resources can be inspected using `kubectl` as specified in their corresponding guides (or watch [`#cp-build-notifications`](https://mojdt.slack.com/messages/CA5MDLM34/) for failures!).
+As we are working on a shared Kubernetes cluster it is useful to put in place limits on the resources that each namespace, pod and container can use. This helps to stop us accidentally entering a situation where a one service impacts the performance of another through using more resources than are available.  
 
-### Accessing your environments
+The first Kubernetes limit we can use is a [LimitRange](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/) which we define in `02-limitrange.yaml`.
+
+The LimitRange object specifies two key resource limits on containers, `defaultRequest` and `default`. `defaultRequest` is the memory and cpu a container will request on startup. This is what the Kubernetes scheduler uses to determine whether there is enough space on the cluster to run your application and what you application will start up with when it is created. `default` is the limit at which your application will be killed or throttled.
+
+In `02-limitrange.yaml` you need to change the value of the `namespace` key to match the name of your namespace in the form `<service-env>`. We have set default values for the limits in the templates. As you learn more about the behaviour of your applications on Kubernetes you can change them.  
+
+```YAML
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: myapp-dev # Your namespace `<servicename-env>`
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 2Gi
+    defaultRequest:
+      cpu: 100m
+      memory: 128Mi
+    type: Container
+```
+
+### `03-resourcequota.yaml`
+
+The [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) object allows us to set a total limit on the resources used in a namespace. As with the LimitRange, the `requests.cpu` and `requests.memory` limits set how much namespace will request on creation. The `limits.cpu` and `limits.memory` define the overall hard limits for the namespace.
+
+In `03-resourcequota.yaml` you need to change the value of the `namespace` key to match the name of your namespace in the form `<service-env>`. We have set default values for the limits in the templates. As you learn more about the behaviour of your applications on Kubernetes you can change them.  
+
+```YAML
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: myapp-dev # Your namespace `<servicename-env>`
+spec:
+  hard:
+    requests.cpu: 4000m
+    requests.memory: 8Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi
+```
+
+### `04-networkpolicy.yaml`
+
+The [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) object defines how groups of pods are allowed to communicate with each other and other network endpoints. By default pods are non-isolated, they accept traffic from any source. We apply a network policy to restrict where traffic can come from, allowing traffic only from the [ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress/) and other pods in your namespace.
+
+In `04-networkpolicy.yaml` you need to change the value of the `namespace` key to match the name of your namespace in the form `<service-env>`.
+
+```YAML
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: myapp-dev # Your namespace `<servicename-env>`
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+```
+
+## Accessing your environments
 
 Once the pipeline has completed you will be able to check that your environment is available by running:
 
-```
-$ kubectl get namespaces
-$ kubectl -n myapp-dev get secrets
-```
+`$ kubectl get namespaces`
 
-This will return a list of the namespaces within the cluster, and you should see yours in the list. Within the namespace, address and credentials for additional AWS resources are available as `Secrets`.
+This will return a list of the namespaces within the cluster, and you should see yours in the list.
+
+You can now run commands in your namespace by appending the `-n` or `--namespace` flag to `kubectl`. So for instance, to see the pods running in our `myenv-dev` namespace, we would run:
+
+`$ kubectl get pods -n myenv-dev` or
+
+`$ kubectl get pods --namespace myenv-dev`
 
 ## Next steps
 Perhaps you would like to [create an ECR repository]({{ "/01-getting-started/003-ecr-setup" | relative_url }}) to push your docker image to.
 
-Next, try [a deployment]({{ "/02-deploying-an-app/001-app-deploy" | relative_url }}) by writing `kubectl`-specific YAML files or [deploy an app]({{ "/02-deploying-an-app/002-app-deploy-helm" | relative_url }}) with [Helm](https://helm.sh/), a Kubernetes package manager.
+If you don't need one, you can try [deploying an app]({{ "/02-deploying-an-app/001-app-deploy-helm" | relative_url }}) with [Helm](https://helm.sh/), a Kubernetes package manager, or [deploying manually]({{ "/02-deploying-an-app/002-app-deploy" | relative_url }}) by writing some custom YAML files.


### PR DESCRIPTION
Note: This is a pretty big change to the page. It would be useful for reviewers to check:

- [ ] Links still work
- [ ] We consistently use angle brackets for variables e.g.`<env-name>`
- [ ] The descriptions of the resources defined in each file make sense
- [ ] The overall page is not too long or complicated - we feel users will still be able to accurately make these changes. 

As part of some prior work on adding network policies and resource
quotas @sablumiah created some templates for all of the resources we
want to define when we create a namespace. These live in
`namespace-resources`.

These templates would be useful for users to work from when creating
their namespaces. At the moment we do not have any information on how to
create a e.g. resource limit in a standard way. When we ask users to do
this we have to rely on them to parse the docs correctly and come up
with a good answer.

This commit changes the user documentation to guide the users through
using those templates when they create a new namespace. This means that
each time a user creates a new namespace using the docs they should get
a set of reasonably standard files with well thought out defaults.

I've also added a brief introduction to what each object that they are
defining does, and a link to the relevant Kubernetes documentation.