### PR TITLE
Improve ECR creation docs

### DIFF
--- a/01-getting-started/003-ecr-setup.md
+++ b/01-getting-started/003-ecr-setup.md
@@ -20,7 +20,7 @@ AWS resources are provisioned through the [cloud-platform-environments](https://
 
   $ cd cloud-platform-environments # navigate into cloud-platform-environments directory.
 
-  $ git co -b add_ecr   # create and checkout new branch.
+  $ git checkout -b add_ecr   # create and checkout new branch.
 
 ```
 
@@ -58,14 +58,14 @@ provider "aws" {
 module "ecr-repo" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=master"
 
-  team_name = "my-team-name"
-  repo_name = "my-app-name"
+  team_name = "<my-team>"
+  repo_name = "<my-app>"
 }
 
 resource "kubernetes_secret" "ecr-repo" {
   metadata {
-    name      = "ecr-repo-my-app-name"
-    namespace = "my-app"
+    name      = "<ecr-repo-my-app>"
+    namespace = "<my-app-dev>"
   }
 
   data {
@@ -84,7 +84,7 @@ This will create an image repository at `<account_number>.dkr.ecr.eu-west-1.amaz
 
   $ git add main.tf
 
-  $ git commit -m "created Terraform module for ECR"
+  $ git commit
 
   $ git push
 

--- a/01-getting-started/003-ecr-setup.md
+++ b/01-getting-started/003-ecr-setup.md
@@ -56,7 +56,7 @@ provider "aws" {
 }
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=master"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=1.0"
 
   team_name = "<my-team>"
   repo_name = "<my-app>"


### PR DESCRIPTION
We have started using angle brackets `<` and `>` to show when a variable
needs to be filled out by the user, e.g. `<team-name>` shows that you
need to put your own team name in that slot. I've updated the example
terraform file to follow this convention.