### PR TITLE
Add/terraform env creation

### DIFF
--- a/01-getting-started/002-env-create.md
+++ b/01-getting-started/002-env-create.md
@@ -22,8 +22,8 @@ You create an environment by adding the definition of the environment in YAML to
 
 [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments)
 
-Adding your environment definition kicks off a pipeline which builds your environment on the appropriate cluster. 
- 
+Adding your environment definition kicks off a pipeline which builds your environment on the appropriate cluster.
+
 ### Set up
 
 First we need to clone the repository, change directory and create a new branch:
@@ -62,64 +62,13 @@ The namespaces directory contains a directory for each of the clusters that you 
 
 Within the cluster directory you will create a directory for your environment in the format `<servicename-env>`, for example `myapp-dev`.
 
-**/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/<servicename-env>**
+**/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/servicename-env/**
 
-The `<servicename-env>` directory for your environment defines the specific resources we will create in your namespace. In this guide we create the base namespace definition and a rolebinding that sets who can perform actions on the namespace.
+The `<servicename-env>` directory for your environment defines the specific resources we will create in your namespace. We describe these resources in more detail in [how we set up an environment](#how-we-set-up-an-environment).
 
-### Create your namespace and namespace-resources
-We will automate the creation of these namespace-resources files using terraform. You will need to install terraform locally.
+### How we set up an environment
 
-```Shell
-$ brew install terraform
-```
-
-In each of these files you need to replace some example values with information about your namespace, team or app. We do this by running terraform commands and filling in the values.
-
-```Shell
-$ cd cloud-platform-environments/namespace-resources/
-$ terraform init
-$ terraform plan
-$ terraform apply
-```
-Our terraform module uses live-0 by default but if you would like to deploy to another cluster.
-
-```Shell
-$ terraform apply -var "cluster=<cluster-name>"
-```
-
-### Terraform Inputs
-
-These are the inputs for the terraform module, that you will need to fill.
-
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| application |  | string | - | yes |
-| business-unit | Area of the MOJ responsible for the service | string | - | yes |
-| cluster | What cluster are you deploying your namespace. I.E cloud-platform-test-1 | string | `cloud-platform-live-0` | no |
-| contact_email | Contact email address for owner of the application | string | - | yes |
-| environment |  | string | - | yes |
-| github_team | This is your team name as defined by the GITHUB api. This has to match the team name on the Github API | string | - | yes |
-| is-production |  | string | `false` | no |
-| namespace | Namespace you would like to create on cluster <application>-<environment>. I.E myapp-dev | string | - | yes |
-| owner | Who is the owner/Who is responsible for this application | string | - | yes |
-| source_code_url | Url of the source code for your application | string | - | yes |
-
-You can access your namespace files under cloud-platform-environments/$namespaces/$cluster/$your-namespace, if satisfied you can then push the changes to your branch and create a pull request against the [`cloud-platform-environments`](https://github.com/ministryofjustice/cloud-platform-environments) master repo.
-
-The cloud platform team will merge the pull request which will kick off the pipeline that builds the environment. You can check whether the build succeeded or failed in the [`#cp-build-notifications`](https://mojdt.slack.com/messages/CA5MDLM34/) slack channel. 
-
-Once this is completed you can skip to ['Accessing your environment'](#Accessing-your-environments)
-
-## Define your environment
-
-We create the environment by adding a directory in the `/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/` directory:
-
-```
-$ cd namespaces/cloud-platform-live-0.k8s.integration.dsd.io/
-$ mkdir myapp-dev
-```
-
-To set up an environment we need to create 5 files in our namespace:
+To set up an environment we create 5 files in the directory for your namespace:
 
 * [`00-namespace.yaml`](#00-namespaceyaml)
 * [`01-rbac.yaml`](#01-rbacyaml)
@@ -127,20 +76,83 @@ To set up an environment we need to create 5 files in our namespace:
 * [`03-resourcequota.yaml`](#03-resourcequotayaml)
 * [`04-networkpolicy.yaml`](#04-networkpolicyyaml)
 
-These files define key elements of the namespace and restrictions we want to place on it so that we have security and resource allocation properties. We describe each of these files in more detail below.
+These files define key elements of the namespace and restrictions we want to place on it so that we have security and resource allocation properties. We will use terraform to create these files from templates. We also describe each of these files [in more detail below](#00-namespaceyaml) in case you want to make future changes.
 
-To get started copy the example versions of these files from the [`namespace-resources`](https://github.com/ministryofjustice/cloud-platform-environments/tree/master/namespace-resources) directory in the `cloud-platform-evironments` repo into your `<servicename-env>` directory.
+### Create your namespace and namespace resources
+
+We automate the creation of the namespace resource files using terraform. You will need to install terraform locally:
 
 ```Shell
-# From the root of the cloud-platform-environments directory
-$ cp namespace-resources/* namespaces/cloud-platform-live-0.k8s.integration.dsd.io/myapp-dev/
+$ brew install terraform
 ```
 
-In each of these files you need to replace some example values with information about your namespace, team or app. We go through each of the changes below.
+In each of the template files you need to replace some example values with information about your namespace, team or app. We do this by running terraform commands and filling in the values.
 
-After you have changed the files commit them and create a pull request against the [`cloud-platform-environments`](https://github.com/ministryofjustice/cloud-platform-environments) master repo.
+These are the inputs for the terraform module, that you will need to fill:
 
-The cloud platform team will merge the pull request which will kick off the pipeline that builds the environment. You can check whether the build succeeded or failed in the [`#cp-build-notifications`](https://mojdt.slack.com/messages/CA5MDLM34/) slack channel.  
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| application |  | string | - | yes |
+| business-unit | Area of the MOJ responsible for the service | string | - | yes |
+| cluster | What cluster are you deploying your namespace. i.e cloud-platform-test-1 | string | `cloud-platform-live-0` | no |
+| contact_email | Contact email address for owner of the application | string | - | yes |
+| environment |  | string | - | yes |
+| github_team | This is your team name as defined by the GITHUB api. This has to match the team name on the Github API | string | - | yes |
+| is-production |  | string | `false` | no |
+| namespace | Namespace you would like to create on cluster <application>-<environment>. i.e myapp-dev | string | - | yes |
+| owner | Who is the owner/Who is responsible for this application | string | - | yes |
+| source_code_url | Url of the source code for your application | string | - | yes |
+
+Create your namespace and these resources files, filling in the values as you are prompted:
+
+```Shell
+$ cd cloud-platform-environments/namespace-resources/
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Our terraform module creates a namespace on live-0 by default but if you would like to deploy to another cluster you can use:
+
+```Shell
+$ terraform apply -var "cluster=<cluster-name>"
+```
+
+You can then access your namespace files under `cloud-platform-environments/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/<your-namespace>`, if satisfied you can then push the changes to your branch and create a pull request against the [`cloud-platform-environments`](https://github.com/ministryofjustice/cloud-platform-environments) master repo.
+
+The cloud platform team will merge the pull request which will kick off the pipeline that builds the environment. You can check whether the build succeeded or failed in the [`#cp-build-notifications`](https://mojdt.slack.com/messages/CA5MDLM34/) slack channel.
+
+## Accessing your environments
+
+Once the pipeline has completed you will be able to check that your environment is available by running:
+
+`$ kubectl get namespaces`
+
+This will return a list of the namespaces within the cluster, and you should see yours in the list.
+
+You can now run commands in your namespace by appending the `-n` or `--namespace` flag to `kubectl`. So for instance, to see the pods running in our `myenv-dev` namespace, we would run:
+
+`$ kubectl get pods -n myenv-dev` or
+
+`$ kubectl get pods --namespace myenv-dev`
+
+## Next steps
+
+[Create an ECR repository]({{ "/01-getting-started/003-ecr-setup" | relative_url }}) to push your application docker image to.
+
+Then you can try [deploying an app to Kubernetes manually]({{ "/02-deploying-an-app/001-app-deploy" | relative_url }}) by writing some custom YAML files or [deploying an app with Helm]({{ "/02-deploying-an-app/002-app-deploy-helm" | relative_url }}), a Kubernetes [package manager]((https://helm.sh/)).
+
+## More information on environment definition
+
+To set up an environment we create 5 files in that directory:
+
+* [`00-namespace.yaml`](#00-namespaceyaml)
+* [`01-rbac.yaml`](#01-rbacyaml)
+* [`02-limitrange.yaml`](#02-limitrangeyaml)
+* [`03-resourcequota.yaml`](#03-resourcequotayaml)
+* [`04-networkpolicy.yaml`](#04-networkpolicyyaml)
+
+These files define key elements of the namespace and restrictions we want to place on it so that we have security and resource allocation properties. We will use terraform to create these files from templates. We also describe each of these files in more detail below in case you want to make changes.
 
 ### `00-namespace.yaml`
 
@@ -260,22 +272,3 @@ spec:
         matchLabels:
           component: ingress-controllers
 ```
-
-## Accessing your environments
-
-Once the pipeline has completed you will be able to check that your environment is available by running:
-
-`$ kubectl get namespaces`
-
-This will return a list of the namespaces within the cluster, and you should see yours in the list.
-
-You can now run commands in your namespace by appending the `-n` or `--namespace` flag to `kubectl`. So for instance, to see the pods running in our `myenv-dev` namespace, we would run:
-
-`$ kubectl get pods -n myenv-dev` or
-
-`$ kubectl get pods --namespace myenv-dev`
-
-## Next steps
-[Create an ECR repository]({{ "/01-getting-started/003-ecr-setup" | relative_url }}) to push your application docker image to.
-
-Then you can try [deploying an app to Kubernetes manually]({{ "/02-deploying-an-app/001-app-deploy" | relative_url }}) by writing some custom YAML files or [deploying an app with Helm]({{ "/02-deploying-an-app/002-app-deploy-helm" | relative_url }}), a Kubernetes [package manager]((https://helm.sh/)).

--- a/01-getting-started/002-env-create.md
+++ b/01-getting-started/002-env-create.md
@@ -22,8 +22,8 @@ You create an environment by adding the definition of the environment in YAML to
 
 [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments)
 
-Adding your environment definition kicks off a pipeline which builds your environment on the appropriate cluster.  
-
+Adding your environment definition kicks off a pipeline which builds your environment on the appropriate cluster. 
+ 
 ### Set up
 
 First we need to clone the repository, change directory and create a new branch:
@@ -65,6 +65,50 @@ Within the cluster directory you will create a directory for your environment in
 **/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/<servicename-env>**
 
 The `<servicename-env>` directory for your environment defines the specific resources we will create in your namespace. In this guide we create the base namespace definition and a rolebinding that sets who can perform actions on the namespace.
+
+### Create your namespace and namespace-resources
+We will automate the creation of these namespace-resources files using terraform. You will need to install terraform locally.
+
+```Shell
+$ brew install terraform
+```
+
+In each of these files you need to replace some example values with information about your namespace, team or app. We do this by running terraform commands and filling in the values.
+
+```Shell
+$ cd cloud-platform-environments/namespace-resources/
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+Our terraform module uses live-0 by default but if you would like to deploy to another cluster.
+
+```Shell
+$ terraform apply -var "cluster=<cluster-name>"
+```
+
+### Terraform Inputs
+
+These are the inputs for the terraform module, that you will need to fill.
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| application |  | string | - | yes |
+| business-unit | Area of the MOJ responsible for the service | string | - | yes |
+| cluster | What cluster are you deploying your namespace. I.E cloud-platform-test-1 | string | `cloud-platform-live-0` | no |
+| contact_email | Contact email address for owner of the application | string | - | yes |
+| environment |  | string | - | yes |
+| github_team | This is your team name as defined by the GITHUB api. This has to match the team name on the Github API | string | - | yes |
+| is-production |  | string | `false` | no |
+| namespace | Namespace you would like to create on cluster <application>-<environment>. I.E myapp-dev | string | - | yes |
+| owner | Who is the owner/Who is responsible for this application | string | - | yes |
+| source_code_url | Url of the source code for your application | string | - | yes |
+
+You can access your namespace files under cloud-platform-environments/$namespaces/$cluster/$your-namespace, if satisfied you can then push the changes to your branch and create a pull request against the [`cloud-platform-environments`](https://github.com/ministryofjustice/cloud-platform-environments) master repo.
+
+The cloud platform team will merge the pull request which will kick off the pipeline that builds the environment. You can check whether the build succeeded or failed in the [`#cp-build-notifications`](https://mojdt.slack.com/messages/CA5MDLM34/) slack channel. 
+
+Once this is completed you can skip to ['Accessing your environment'](#Accessing-your-environments)
 
 ## Define your environment
 

--- a/01-getting-started/002-env-create.md
+++ b/01-getting-started/002-env-create.md
@@ -112,7 +112,7 @@ $ terraform plan
 $ terraform apply
 ```
 
-Our terraform module creates a namespace on live-0 by default but if you would like to deploy to another cluster you can use:
+Our terraform module creates the files for a new namespace on the live-0 cluster by default but if you would like to deploy to another cluster you can use:
 
 ```Shell
 $ terraform apply -var "cluster=<cluster-name>"


### PR DESCRIPTION
 Add automatic environment creation to docs

@jojuolape [has
added](ministryofjustice/cloud-platform-environments#166)
functionality for us to automatically generate the namespace resource
files using terraform. He also did a draft of updating the guide to
reflect the change.

I've built on that to change the flow of the document a little and
remove some of the bits that were now overly wordly or incorrect. I've
tested out the method as well to make sure that this is resonably clear from a
user perspective.