### PR TITLE
Add Prometheus Links Documentation + Fix Broken Links

### DIFF
--- a/03-other-topics/004-kibana.md
+++ b/03-other-topics/004-kibana.md
@@ -2,13 +2,10 @@
 ## Introduction
 This document is intended to assist engineers in accessing application and system logs stored in a centralised Elasticsearch cluster. Using a combination of Fluentd, AWS's Elasticsearch cluster and Kibana the Cloud Platform collects, indexes and presents your application and system log data enabling you to query using Kibana’s standard query language (based on Lucene query syntax). All that's required is that your application writes to stdout. 
 
-Production and non-production data will be indexed in seperate clusters. 
 ## Quick start
 Live-0 cluster: 
 [https://kibana.apps.cloud-platform-live-0.k8s.integration.dsd.io/_plugin/kibana](https://kibana.apps.cloud-platform-live-0.k8s.integration.dsd.io/_plugin/kibana)
 
-Test-1 cluster:
-[https://kibana.apps.cloud-platform-test-1.k8s.integration.dsd.io/_plugin/kibana](https://kibana.apps.cloud-platform-test-1.k8s.integration.dsd.io/_plugin/kibana)
 ## How to get my data into Elasticsearch
 As long as your application is writing to stdout, it'll be collected by fluentd and passed to the Elasticsearch cluster. Use one of the links above and authenticate with your GitHub username and password. 
 ## How do I use Kibana?

--- a/03-other-topics/004-kibana.md
+++ b/03-other-topics/004-kibana.md
@@ -4,16 +4,16 @@ This document is intended to assist engineers in accessing application and syste
 
 Production and non-production data will be indexed in seperate clusters. 
 ## Quick start
-Live
-https://kibana.apps.cloud-platform-live-0.k8s.integration.dsd.io/_plugin/kibana
+Live-0 cluster: 
+[https://kibana.apps.cloud-platform-live-0.k8s.integration.dsd.io/_plugin/kibana](https://kibana.apps.cloud-platform-live-0.k8s.integration.dsd.io/_plugin/kibana)
 
-Test
-https://kibana.apps.cloud-platform-test-1.k8s.integration.dsd.io/_plugin/kibana
+Test-1 cluster:
+[https://kibana.apps.cloud-platform-test-1.k8s.integration.dsd.io/_plugin/kibana](https://kibana.apps.cloud-platform-test-1.k8s.integration.dsd.io/_plugin/kibana)
 ## How to get my data into Elasticsearch
 As long as your application is writing to stdout, it'll be collected by fluentd and passed to the Elasticsearch cluster. Use one of the links above and authenticate with your GitHub username and password. 
 ## How do I use Kibana?
 
-https://www.elastic.co/guide/en/kibana/6.3/search.html
+[https://www.elastic.co/guide/en/kibana/6.3/search.html](https://www.elastic.co/guide/en/kibana/6.3/search.html)
 
-https://www.elastic.co/guide/en/beats/packetbeat/current/kibana-queries-filters.html
+[https://www.elastic.co/guide/en/beats/packetbeat/current/kibana-queries-filters.html](https://www.elastic.co/guide/en/beats/packetbeat/current/kibana-queries-filters.html)
 

--- a/03-other-topics/005-k8s-basics.md
+++ b/03-other-topics/005-k8s-basics.md
@@ -13,24 +13,24 @@ Kubernetes is very often referred to as **"K8s"**, purely for the reason, that t
 If Kubernetes is a totally new concept to you, then firstly you should probably check out a few of the resources linked below:
 
 Official Website: 
-https://kubernetes.io/
+[https://kubernetes.io](https://kubernetes.io)
 
 Offical Docs: 
-https://kubernetes.io/docs/concepts/
+[https://kubernetes.io/docs/concepts](https://kubernetes.io/docs/concepts)
 
 Quick concept video: 
-https://www.youtube.com/watch?v=IMOZCDhH7do
+[https://www.youtube.com/watch?v=IMOZCDhH7do](https://www.youtube.com/watch?v=IMOZCDhH7do)
 
 A part of the concept that is missing from the main offical document is Ingress.
-Here's a link that expalins that concept: https://kubernetes.io/docs/concepts/services-networking/ingress/
+Here's a link that expalins that concept: [https://kubernetes.io/docs/concepts/services-networking/ingress](https://kubernetes.io/docs/concepts/services-networking/ingress)
 
 ## Experiment with Local Hosting 
 
 To keep costs low and for learning the basics, it is possible to host a Kubernetes Cluster locally on your machine. Docker and Minikube both provide tools for this:
 
-Docker: https://docs.docker.com/docker-for-mac/kubernetes/
+Docker: [https://docs.docker.com/docker-for-mac/kubernetes](https://docs.docker.com/docker-for-mac/kubernetes)
 
-Minikube: https://kubernetes.io/docs/setup/minikube/
+Minikube: [https://kubernetes.io/docs/setup/minikube](https://docs.docker.com/docker-for-mac/kubernetes)
 
 Kubernetes is normally used with one of the big 3 cloud providers. Amazon Web Services, Google Cloud Engine, and Microsoft Azure.
 
@@ -38,7 +38,7 @@ Kubernetes is normally used with one of the big 3 cloud providers. Amazon Web Se
 
 Kubernetes has it's own official CLI tool for interacting with a Cluster called `kubectl`. It is certainly worth learning the basics of `kubectl`, As the vast majority of time interacting with Kubernetes will be through this tool.
 
-We have our own page on [Kubectl Basics](/01-getting-started/003-ecr-setup/#creating-an-ecr-repository).
+We have our own page on [Kubectl Basics](/03-other-topics/003-quick-reference/#kubectl-quick-reference).
 
 ## Online Courses
 
@@ -47,7 +47,7 @@ You will find a multitude of courses online that offer to teach the basics of Ku
 Two popular course sites, for example are:
 
 ### Pluralsight
-https://www.pluralsight.com/courses/getting-started-kubernetes
+[https://www.pluralsight.com/courses/getting-started-kubernetes](https://www.pluralsight.com/courses/getting-started-kubernetes)
 
 ### Udacity
-https://eu.udacity.com/course/scalable-microservices-with-kubernetes--ud615
+[https://eu.udacity.com/course/scalable-microservices-with-kubernetes--ud615](https://eu.udacity.com/course/scalable-microservices-with-kubernetes--ud615)

--- a/03-other-topics/006-prometheus.md
+++ b/03-other-topics/006-prometheus.md
@@ -1,0 +1,40 @@
+---
+category: cloud-platform
+expires: 2019-01-01
+---
+# Using the Cloud Platform Prometheus, AlertManager and Grafana 
+## Introduction
+Prometheus, AlertManager and Grafana have been installed on Live-0 to ensure the reliability and availability of the Cloud Platform. This document will briefly outline how to access the monitoring tools and where to find further information. 
+
+## What is Prometheus
+
+Prometheus is an open-source systems monitoring and alerting toolkit originally built at SoundCloud. The Cloud Platform uses [Prometheus Operator from CoreOS](https://github.com/coreos/prometheus-operator) which allows a number of Prometheus instances to be installed on a cluster.
+
+Prometheus scrapes metrics from instrumented jobs, either directly or via an intermediary push gateway for short-lived jobs. It stores all scraped samples locally and runs rules over this data to either aggregate and record new time series from existing data or generate alerts. Grafana or other API consumers can be used to visualize the collected data.
+
+## What is AlertManager
+
+The Alertmanager handles alerts sent by client applications such as the Prometheus server. It takes care of deduplicating, grouping, and routing them to the correct receiver integration such PagerDuty. It also takes care of silencing and inhibition of alerts.
+
+## What is Grafana
+
+Grafana allows you to query, visualize, alert on and understand your metrics no matter where they are stored. Create, explore, and share dashboards with your team and foster a data driven culture.
+
+## How to access monitoring tools
+
+All links provided below require you to authenticate with your Github account. 
+
+Prometheus: [https://prometheus.apps.cloud-platform-live-0.k8s.integration.dsd.io](https://prometheus.apps.cloud-platform-live-0.k8s.integration.dsd.io)
+
+AlertManager: [https://alertmanager.apps.cloud-platform-live-0.k8s.integration.dsd.io](https://alertmanager.apps.cloud-platform-live-0.k8s.integration.dsd.io/)
+
+Grafana: [https://grafana.apps.cloud-platform-live-0.k8s.integration.dsd.io](https://grafana.apps.cloud-platform-live-0.k8s.integration.dsd.io)
+
+
+## Further documentation
+
+[Prometheus querying](https://prometheus.io/docs/prometheus/latest/querying/basics)
+
+[AlertManager](https://prometheus.io/docs/alerting/alertmanager)
+
+[Architecture](https://prometheus.io/docs/introduction/overview/#architecture)


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/cloud-platform/issues/409
& 
Connects to https://github.com/ministryofjustice/cloud-platform/issues/405

**WHAT**
1. Fix the broken links in the Kibana documentation:
https://ministryofjustice.github.io/cloud-platform-user-docs/03-other-topics/004-kibana/#how-to-access-my-log-data-using-kibana
2. Adds a document to the user docs called `Using the Cloud Platform Prometheus, AlertManager and Grafana`.
3. Fixes the broken links in the `Kubernetes basics` docs:
https://ministryofjustice.github.io/cloud-platform-user-docs/03-other-topics/005-k8s-basics/#kubernetes-basics---links-to-helpful-beginner-resources

**WHY**
1. This will allow users to click the hyperlinks and redirect to the relevant page. I found this issue whilst attempting to fix another ticket. 
2. As users want to know how to access the Cloud Platform Prometheus, AlertManager or Grafana. They can find guidance on this in the user guide. This links to Connects to https://github.com/ministryofjustice/cloud-platform/issues/409.
3. It was pointed out by users that the `Kubernetes basics` docs has a broken link. This link has now been fixed under Connects to https://github.com/ministryofjustice/cloud-platform/issues/405.