### PR TITLE
Amend env creation doc

### DIFF
--- a/01-getting-started/002-env-create.md
+++ b/01-getting-started/002-env-create.md
@@ -108,7 +108,6 @@ Create your namespace and these resources files, filling in the values as you ar
 ```Shell
 $ cd cloud-platform-environments/namespace-resources/
 $ terraform init
-$ terraform plan
 $ terraform apply
 ```
 


### PR DESCRIPTION
Users should not be directed to run `terraform plan` when creating an environment as it asks them for the same input twice for no reason.