### PR TITLE
Make it clearer how to get started

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,11 +6,15 @@ The Ministry of Justice cloud platform is a platform for hosting services develo
 
 ### Who is the platform for
 
-The platform is for teams working anywhere in the Ministry of Justice that need to run software applications. If you are interested in becoming a user, drop into the MoJ Digital slack channel `#cloud-platform-users` or email the cloud platform team `platforms@digital.justice.gov.uk`.
+The platform is for teams working anywhere in the Ministry of Justice that need to run software applications. To get started you need to be part of a team in the Ministry of Justice GitHub organisation. Once you are, you can start to deploy applications using the guides below. 
 
 ### What do we currently support
 
-Users can create non-production and production environments and get access to the Kubernetes API for those environments. 
+Users can create non-production and production environments and get access to the Kubernetes API for those environments.
+
+### Help and support
+
+For help or support, drop into the MoJ Digital slack channel `#cloud-platform-users`, raise an issue on the [Ministry of Justice cloud-platform](https://github.com/ministryofjustice/cloud-platform) repo, or email the cloud platform team `platforms@digital.justice.gov.uk`.
 
 ## Getting started
 


### PR DESCRIPTION
We had a user request for "access" to the platform in the
`#cloud-platform-users` channel. This confused us as all you need to
access the platform is to be part of a Github team in the MoJ Github
organisation.

Turns out we had guidance that said people should ask in the channel to
get started. They don't need to do this. So I've made it clearer that
they can just get on with it if they have the right permissions and
instead added a section to say that they can get help and support
through the channel.