### PR TITLE
Add a link to Cloud Platform support documentation

### DIFF
--- a/03-other-topics/007-cloud-platform-support.md
+++ b/03-other-topics/007-cloud-platform-support.md
@@ -1,0 +1,8 @@
+---
+category: cloud-platform
+expires: 2019-01-01
+---
+# Cloud Platform Support
+
+[https://docs.google.com/document/d/1M89TXQJIQAqu8yb2wzatlI8PgsXrgOi-GxLtB76XgjU/edit?usp=sharing](https://docs.google.com/document/d/1M89TXQJIQAqu8yb2wzatlI8PgsXrgOi-GxLtB76XgjU/edit?usp=sharing)
+

--- a/03-other-topics/007-cloud-platform-support.md
+++ b/03-other-topics/007-cloud-platform-support.md
@@ -5,4 +5,3 @@ expires: 2019-01-01
 # Cloud Platform Support
 
 [https://docs.google.com/document/d/1M89TXQJIQAqu8yb2wzatlI8PgsXrgOi-GxLtB76XgjU/edit?usp=sharing](https://docs.google.com/document/d/1M89TXQJIQAqu8yb2wzatlI8PgsXrgOi-GxLtB76XgjU/edit?usp=sharing)
-


### PR DESCRIPTION
connects to ministryofjustice/cloud-platform#446

**WHAT**
- Add a link to Cloud Platform support documentation

WHY
We have recently communicated changes with regard to support for the new platform. By adding it to our documentation, new and existing users have full visibility of the support provided. 

Note:
As the cloud platform is in it's early stages, the support document may change. After discussion with @AntonyBishop and @kalbir, at this moment in time it is easier to edit the google doc. Once the support document is set in stone, the link can be removed and replaced with the support document in markdown format.