### PR TITLE
Add description of https headers for probes

### DIFF
--- a/99-other-topics/008-zero-downtime-deployment.md
+++ b/99-other-topics/008-zero-downtime-deployment.md
@@ -29,5 +29,27 @@ The ability to constantly update your application, with zero downtime, brings a 
 
 If you'd like to read more in-depth into rolling updates, then Kubernetes has some great documentation [here](https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/).
 
+### Readiness/Liveness probes and SSL in Rails applications
 
+For zero downtime deployments, you will need a readiness probe in your application, so that the cluster knows when your container is ready to receive traffic. You will also need a liveness probe, so that the cluster knows if it needs to restart your container after a crash.
+
+SSL will be terminated outside of your pod, so your probes will need to respond to HTTP requests. However, Ruby on Rails applications are sometimes configured to only respond to HTTPS traffic (by adding `config.force_ssl = true` in the `config/environments/production.rb` file).
+
+In this case, the application will respond to any HTTP request with a 301 redirect, asking the requester to resend the request to the equivalent HTTPS URL. This will cause your probes to fail, because the redirect will not be followed.
+
+To fix this, the probe needs to tell the application that it is an HTTPS request, even though it isn't, so that the application will process the request rather than sending a redirect response. You can do this by adding some HTTP headers to your probe definitions like this:
+
+```
+readinessProbe:
+  httpGet:
+    path: /ping.json
+    port: 3000
+    httpHeaders:
+      - name: X-Forwarded-Proto
+        value: https
+      - name: X-Forwarded-Ssl
+        value: "on"
+```
+
+This will send an HTTP request to `/ping.json`, but the rails application will respond as if it is HTTPS, and your probe should work as expected. This works for both readiness and liveness probes.
 

--- a/99-other-topics/008-zero-downtime-deployment.md
+++ b/99-other-topics/008-zero-downtime-deployment.md
@@ -35,7 +35,7 @@ For zero downtime deployments, you will need a readiness probe in your applicati
 
 SSL will be terminated outside of your pod, so your probes will need to respond to HTTP requests. However, Ruby on Rails applications are sometimes configured to only respond to HTTPS traffic (by adding `config.force_ssl = true` in the `config/environments/production.rb` file).
 
-In this case, the application will respond to any HTTP request with a 301 redirect, asking the requester to resend the request to the equivalent HTTPS URL. This will cause your probes to fail, because the redirect will not be followed.
+In this case, the application will respond to any HTTP request with a redirect status code, asking the requester to resend the request to the equivalent HTTPS URL. This will cause your probes to fail, because the redirect will not be followed.
 
 To fix this, the probe needs to tell the application that it is an HTTPS request, even though it isn't, so that the application will process the request rather than sending a redirect response. You can do this by adding some HTTP headers to your probe definitions like this:
 


### PR DESCRIPTION
This came up on [slack](https://mojdt.slack.com/archives/C57UPMZLY/p1551866194097100)

For rails applications with force_ssl = true, probes need extra
http headers. Adding this explanation here will help developers
avoid problems with failing probes, without needing our help.