### PR TITLE
Amend instructions to git clone via https, not ssh

### DIFF
--- a/02-deploying-an-app/001-app-deploy.md
+++ b/02-deploying-an-app/001-app-deploy.md
@@ -35,7 +35,7 @@ This guide assumes the following:
 
 * Clone the [demo application](https://github.com/ministryofjustice/cloud-platform-helloworld-ruby-app)
 
-      git clone git@github.com:ministryofjustice/cloud-platform-helloworld-ruby-app.git
+      git clone https://github.com/ministryofjustice/cloud-platform-helloworld-ruby-app
       cd cloud-platform-helloworld-ruby-app
 
 * Build the docker image


### PR DESCRIPTION
If users are not in the MoJ/webops github team, they won't be able
to clone the helloworld demo app. via SSH.