### PR TITLE
Add instructions on how to contribute to the guide

### DIFF
--- a/99-other-topics/009-contributing-to-this-doc.md
+++ b/99-other-topics/009-contributing-to-this-doc.md
@@ -1,0 +1,13 @@
+---
+category: cloud-platform
+expires: 2020-03-08
+---
+
+# Contributing to this document
+
+This guide is built using [GitHub Pages][gh-pages].
+
+If you would like to contribute to this guide, please fork [the repository][repo], make your changes and then raise a pull request.
+
+[repo]: https://github.com/ministryofjustice/cloud-platform-user-docs
+[gh-pages]: https://pages.github.com/


### PR DESCRIPTION
People who are familiar with github pages will know how to go from

https://ministryofjustice.github.io/cloud-platform-user-docs

...to

https://github.com/ministryofjustice/cloud-platform-user-docs

For those who don't, this change provides instructions on how to
find the source repo and contribute to the guide.